### PR TITLE
#12 support Headers_out#[]= only global plugin use

### DIFF
--- a/src/ts_mruby_internal.cpp
+++ b/src/ts_mruby_internal.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 
 using namespace std;
+using namespace atscppapi;
 
 // These status reasons are based on proxy/hdrs/HTTP.cc on trafficserver.
 // XXX Temporary fix. We should use this function from atscppapi.
@@ -167,3 +168,20 @@ void RputsPlugin::handleInputComplete() {
   InterceptPlugin::produce(response);
   InterceptPlugin::setOutputComplete();
 }
+
+void HeaderRewritePlugin::addRewriteRule(const std::pair<std::string, std::string> entry) {
+  _headers.push_back(entry);
+}
+
+void HeaderRewritePlugin::handleSendResponseHeaders(Transaction &transaction) {
+  auto& resp = transaction.getClientResponse();
+
+  Headers& resp_headers = resp.getHeaders();
+  for_each(_headers.begin(), _headers.end(),
+           [&resp_headers](pair<string, string> entry) {
+    resp_headers[entry.first] = entry.second;
+  });
+
+  transaction.resume();
+}
+

--- a/src/ts_mruby_internal.hpp
+++ b/src/ts_mruby_internal.hpp
@@ -45,9 +45,24 @@ public:
   void handleInputComplete();
 };
 
+class HeaderRewritePlugin : public atscppapi::TransactionPlugin {
+private:
+  HeaderVec _headers;
+
+public:
+  HeaderRewritePlugin(atscppapi::Transaction &transaction)
+    : atscppapi::TransactionPlugin(transaction) {
+      atscppapi::TransactionPlugin::registerHook(HOOK_SEND_RESPONSE_HEADERS);
+  }
+
+  void addRewriteRule(const std::pair<std::string, std::string> entry);
+  void handleSendResponseHeaders(atscppapi::Transaction &transaction);
+};
+
 struct TSMrubyContext {
   atscppapi::Transaction *transaction;
   RputsPlugin *rputs;
+  HeaderRewritePlugin *header_rewrite;
 };
 
 #endif // TS_MRUBY_CORE_H


### PR DESCRIPTION
https://github.com/syucream/ts_mruby/issues/12

This PR is not full support of `Headers_out#[]=`. See https://github.com/syucream/ts_mruby/issues/12