### PR TITLE
Fix #82 ATS::EventSystem not to require implements of all of handler methods

### DIFF
--- a/src/ts_mruby_eventsystem.cpp
+++ b/src/ts_mruby_eventsystem.cpp
@@ -19,11 +19,6 @@
 using namespace std;
 using namespace atscppapi;
 
-// TODO Support some aliases ... ?
-static const string SEND_REQUEST_HDR_HANDLER  = "on_send_request_hdr";
-static const string READ_RESPONSE_HDR_HANDLER = "on_read_response_hdr";
-static const string SEND_RESPONSE_HDR_HANDLER = "on_send_response_hdr";
-
 void
 EventSystemPlugin::handleSendRequestHeaders(Transaction& transaction) {
   auto context = shared_ptr<TSMrubyContext>(new TSMrubyContext());

--- a/src/ts_mruby_eventsystem.hpp
+++ b/src/ts_mruby_eventsystem.hpp
@@ -12,6 +12,11 @@
 #include <atscppapi/TransactionPlugin.h>
 #include <mruby.h>
 
+// TODO Support some aliases ... ?
+static const char* SEND_REQUEST_HDR_HANDLER  = "on_send_request_hdr";
+static const char* READ_RESPONSE_HDR_HANDLER = "on_read_response_hdr";
+static const char* SEND_RESPONSE_HDR_HANDLER = "on_send_response_hdr";
+
 void ts_mrb_eventsystem_class_init(mrb_state *mrb, struct RClass *rclass);
 
 /**
@@ -26,14 +31,19 @@ private:
 public:
   EventSystemPlugin(atscppapi::Transaction &transaction, mrb_state* mrb, struct RClass* rclass)
     : atscppapi::TransactionPlugin(transaction) {
-    // TODO High cost. It should switch hook resistration by any criteria.
-    registerHook(HOOK_SEND_REQUEST_HEADERS);
-    registerHook(HOOK_READ_RESPONSE_HEADERS);
-    registerHook(HOOK_SEND_RESPONSE_HEADERS);
-
-    // Should its handled in outer of this class?
     mrb_value v = mrb_obj_new(mrb, rclass, 0, nullptr);
 
+    if (mrb_respond_to(mrb, v, mrb_intern_cstr(mrb, SEND_REQUEST_HDR_HANDLER))) {
+      registerHook(HOOK_SEND_REQUEST_HEADERS);
+    }
+    if (mrb_respond_to(mrb, v, mrb_intern_cstr(mrb, READ_RESPONSE_HDR_HANDLER))) {
+      registerHook(HOOK_READ_RESPONSE_HEADERS);
+    }
+    if (mrb_respond_to(mrb, v, mrb_intern_cstr(mrb, SEND_RESPONSE_HDR_HANDLER))) {
+      registerHook(HOOK_SEND_RESPONSE_HEADERS);
+    }
+
+    // Should its handled in outer of this class?
     auto* tlmrb = ts_mruby::getThreadLocalMrubyStates();
     handler_obj_ = tlmrb->getManager().lend_mrb_value(v);
   }


### PR DESCRIPTION
https://github.com/syucream/ts_mruby/issues/82